### PR TITLE
Remove subr

### DIFF
--- a/yank-dwim.el
+++ b/yank-dwim.el
@@ -35,8 +35,6 @@
 
 (require 'org-macs)
 (require 'simple)
-(require 'subr)
-
 
 ;;; yank-dwim for markdown ====================================================
 


### PR DESCRIPTION
Hi,

This removes `subr`.

Emacs complains about it not being provided.

![image](https://github.com/user-attachments/assets/d89d66f9-34a1-4974-860a-597e7eb0ab19)
